### PR TITLE
Fix healthcheck whitespace

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -2,9 +2,9 @@
 set -e
 MODE=${RUN_MODE:-full}
 if [ "$MODE" = "fpm-only" ]; then
-  pgrep php-fpm > /dev/null
-  exit $?
+  pgrep php-fpm > /dev/null
+  exit $?
 else
-  pgrep php-fpm > /dev/null && pgrep nginx > /dev/null
-  exit $?
+  pgrep php-fpm > /dev/null && pgrep nginx > /dev/null
+  exit $?
 fi


### PR DESCRIPTION
## Summary
- replace non-breaking spaces in `healthcheck.sh`
- ensure newline at EOF

## Testing
- `bash -n healthcheck.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f774ddb4c8326afe848ca01b175ec