### PR TITLE
docs: add compact image instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,20 @@ To run it interactively:
 docker run -it hezzit-roundcube:dev
 ```
 
+### 🛪 Compact Image
+
+If you want a smaller image footprint, you can use [docker-slim](https://github.com/docker-slim/docker-slim):
+
+```bash
+docker-slim build --tag hezzit-roundcube:slim .
+```
+
+Alternatively, add the `--squash` option during build (if supported):
+
+```bash
+docker build --squash -t hezzit-roundcube:squashed .
+```
+
 ---
 
 ## 🙏 Acknowledgements


### PR DESCRIPTION
## Summary
- add small section on building a compact image in README

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683f778042e4832682eeb49b204f8a0a