### PR TITLE
Add instructions for mint-slim

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,29 @@ To run it interactively:
 docker run -it hezzit-roundcube:dev
 ```
 
+## 🍃 Slim Image Generation
+
+The script `mint-slim.sh` is included in the container to assist
+`docker-slim` during the build process. It touches important paths and
+executes key commands so the final slim image keeps only the files that
+are actually needed.
+
+### Quick Steps
+
+1. Build the regular image:
+
+   ```bash
+   docker build -t hezzit-roundcube:dev .
+   ```
+
+2. Generate the slim variant using the helper script:
+
+   ```bash
+   docker-slim build --http-probe-off --entrypoint /mint-slim.sh hezzit-roundcube:dev
+   ```
+
+3. Use the resulting image tagged with the `-slim` suffix.
+
 ---
 
 ## 🙏 Acknowledgements


### PR DESCRIPTION
## Summary
- document purpose of `mint-slim.sh`
- show how to create a slim image with `docker-slim`

## Testing
- `bash -n mint-slim.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f77652288832693c539f1b0d7a43f